### PR TITLE
fix: QPlainTextEdit 纯文本

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 - [`QSlider`移动条、`QScrollBar`滚动条、`QProgressBar`进度条控件的联动](https://blog.csdn.net/qq_33154343/article/details/101003081)【QtQProgressBarEx】
 - [仪表盘`QSlider`和数值显示`QLCD_NUmber`的讲解和使用](https://blog.csdn.net/qq_33154343/article/details/101003115)【QtQdialQLCDEx】
 -  [时间日期(`QTime`/`QDate`/`QDateTime`)和定时器(`QTimer`)的介绍和使用](https://blog.csdn.net/qq_33154343/article/details/101040841)【QtDateTimeEx】
-- [`QComboBox`(下拉列表框)和`QPlainTextEdit`(多行富文本编辑器)的用法](https://blog.csdn.net/qq_33154343/article/details/101127870) 【QtQcomboBoxEx】
+- [`QComboBox`(下拉列表框)和`QPlainTextEdit`(多行纯文本编辑器)的用法](https://blog.csdn.net/qq_33154343/article/details/101127870) 【QtQcomboBoxEx】
 - [列表控件`QListWidget`和工具按钮`QToolButton`的和用法](https://blog.csdn.net/qq_33154343/article/details/101314908)【QtQListWidgetEx】
 - [目录树组件`QTreeWidget`和停靠区域组件`QDockWidget`的用法](https://blog.csdn.net/qq_33154343/article/details/103467757)【QtQTreeWidgetEx】
 - [`QTableWidget`表格组件的属性介绍和使用](https://blog.csdn.net/qq_33154343/article/details/103485154)【QtQTableWidgetEx】


### PR DESCRIPTION
哈哈～
据我所知，QPlainTextEdit 应该是纯文本编辑器，而 QTextEdit 才是富文本编辑器。

The QTextEdit class provides a widget that is used to edit and display both plain and rich text. [link](https://doc.qt.io/qt-5/qtextedit.html)
The QPlainTextEdit class provides a widget that is used to edit and display plain text. [link](https://doc.qt.io/qt-5/qplaintextedit.html)